### PR TITLE
refactor bills by query method.

### DIFF
--- a/app/services/bill_service.rb
+++ b/app/services/bill_service.rb
@@ -10,10 +10,14 @@ class BillService
     response = Rails.cache.fetch(bills_key) do
       fetch_bills_by_query_from_api
     end
-    json = JSON.parse(response.body, symbolize_names: true)
-    bill_search_result = json[:searchresult]
-
-    json
+  
+    if response&.body
+      json = JSON.parse(response.body, symbolize_names: true)
+      bill_search_result = json[:searchresult]
+      json
+    else
+      # Handle the nil response appropriately
+    end
   end
 
   def bills_by_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.0].define(version: 2023_08_02_161504) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -84,6 +84,8 @@ VCR.configure do |config|
   config.default_cassette_options = { re_record_interval: 1.days }
   config.filter_sensitive_data('LEGISCAN_KEY') { ENV['LEGISCAN_KEY'] }
   config.filter_sensitive_data('STATES_KEY') { ENV['STATES_KEY'] }
+  config.filter_sensitive_data('GOOGLE_CLIENT_ID') { ENV['GOOGLE_CLIENT_ID'] }
+  config.filter_sensitive_data('GOOGLE_CLIENT_SECRET') { ENV['GOOGLE_CLIENT_SECRET'] }
   config.default_cassette_options = { :allow_playback_repeats => true }
   config.configure_rspec_metadata!
 end


### PR DESCRIPTION
# high level what you did:
- The bills by query method wasn't caching the response

## Details:
Update from this method:
```
def bills_by_query
    bills_key = ["bills_by_query", @state_abbv, @query_keyword]
    response = Rails.cache.fetch(bills_key) do
      fetch_bills_by_query_from_api
    end
    json = JSON.parse(response.body, symbolize_names: true)
    bill_search_result = json[:searchresult]

    json
  end
```
to this method:
```
def bills_by_query
  bills_key = ["bills_by_query", @state_abbv, @query_keyword]
  response = Rails.cache.fetch(bills_key) do
    fetch_bills_by_query_from_api
  end

  if response&.body
    json = JSON.parse(response.body, symbolize_names: true)
    bill_search_result = json[:searchresult]
    json
  else
    # Handle the nil response appropriately
  end
end

```


## Overall Checklist:
- [ ] tests written for all methods added
- [ ] test coverage above 90%
- [ ] RSpec running clean
- [ ] ran rails s -- features working properly!
- [ ] pulled/merged milestone branch before submitting PR